### PR TITLE
Hardware library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
   * 10/10/2018 - Created boilerplate back-end app
   * 19/10/2018 - Implemented a caching mechanism for the back-end
   * 22/10/2018 - Created User System
+  * 05/11/2018 - Implemented hardware library system

--- a/back-end/CHANGELOG.md
+++ b/back-end/CHANGELOG.md
@@ -6,3 +6,4 @@
   * 19/10/2018 - Implemented a caching mechanism
   * 21/10/2018 - Fixed inconsistencies in the caching mechanism
   * 22/10/2018 - Implemented User System
+  * 05/10/2018 - Implemented hardware library system and tests

--- a/back-end/CHANGELOG.md
+++ b/back-end/CHANGELOG.md
@@ -6,4 +6,4 @@
   * 19/10/2018 - Implemented a caching mechanism
   * 21/10/2018 - Fixed inconsistencies in the caching mechanism
   * 22/10/2018 - Implemented User System
-  * 05/10/2018 - Implemented hardware library system and tests
+  * 05/11/2018 - Implemented hardware library system and tests

--- a/back-end/src/app.ts
+++ b/back-end/src/app.ts
@@ -128,7 +128,9 @@ const createDatabaseOptions = (): ConnectionOptions[] => {
     password: process.env.DB_PASSWORD,
     database: process.env.DB_DATABASE,
     entities: [
-      __dirname + "/db/entity/user{.js,.ts}"
+      __dirname + "/db/entity/user{.js,.ts}",
+      __dirname + "/db/entity/hardwareItem{.js,.ts}",
+      __dirname + "/db/entity/reservedHardwareItem{.js,.ts}"
     ],
     // Per TypeOrm documentation, this is unsafe for production
     // We should instead use migrations to change the database

--- a/back-end/src/controllers/hardwareController.ts
+++ b/back-end/src/controllers/hardwareController.ts
@@ -36,9 +36,11 @@ export class HardwareController {
    */
   public async take(req: Request, res: Response, next: Function): Promise<void> {
     try {
-      const success: boolean = await takeItem(req.body.token);
-      if (success) {
-        res.send({"message": "Success"});
+      const takenItem: boolean  = await takeItem(req.body.token);
+      if (takenItem !== undefined) {
+        res.send({
+          "message": takenItem ? "Item has been taken from the library" : "Item has been returned to the library"
+        });
       } else {
         return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Action failed!"));
       }

--- a/back-end/src/controllers/hardwareController.ts
+++ b/back-end/src/controllers/hardwareController.ts
@@ -35,9 +35,9 @@ export class HardwareController {
     try {
       const success: boolean = await takeItem(req.body.token);
       if (success) {
-        res.send({"message": "Item has been taken!"});
+        res.send({"message": "Success"});
       } else {
-        return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Item cannot be taken!"));
+        return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Action failed!"));
       }
     } catch (err) {
       return next(new ApiError(HttpResponseCode.INTERNAL_ERROR, err.message));

--- a/back-end/src/controllers/hardwareController.ts
+++ b/back-end/src/controllers/hardwareController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { reserveItem, takeItem } from "../util/hardwareLibrary";
+import { reserveItem, takeItem, getAllHardwareItems, addAllHardwareItems } from "../util/hardwareLibrary";
 import { ApiError } from "../util/errorHandling/apiError";
 import { HttpResponseCode } from "../util/errorHandling/httpResponseCode";
 /**
@@ -44,6 +44,47 @@ export class HardwareController {
       } else {
         return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Action failed!"));
       }
+    } catch (err) {
+      return next(new ApiError(HttpResponseCode.INTERNAL_ERROR, err.message));
+    }
+  }
+
+  /**
+   * Gets all the items from the database
+   */
+  public async getAllItems(req: Request, res: Response, next: Function): Promise<void> {
+    try {
+      const allItems: Object[] = await getAllHardwareItems();
+      if (allItems !== undefined) {
+        res.send(allItems);
+      } else {
+        return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Action failed!"));
+      }
+    } catch (err) {
+      return next(new ApiError(HttpResponseCode.INTERNAL_ERROR, err.message));
+    }
+  }
+
+  /**
+   * Adds all the items in the request to the database
+   * Use the following format to add the items:
+   * [{
+   * "itemName": "...",
+   * "itemURL": "...",
+   * "itemDescription": "...",
+   * "itemStock": 0
+   * },
+   * {
+   * "itemName": "...",
+   * "itemURL": "...",
+   * "itemDescription": "...",
+   * "itemStock": 0
+   * }]
+   */
+  public async addAllItems(req: Request, res: Response, next: Function): Promise<void> {
+    try {
+      await addAllHardwareItems(req.body);
+      res.send({"message": "Added all items"});
     } catch (err) {
       return next(new ApiError(HttpResponseCode.INTERNAL_ERROR, err.message));
     }

--- a/back-end/src/controllers/hardwareController.ts
+++ b/back-end/src/controllers/hardwareController.ts
@@ -1,0 +1,46 @@
+import { Request, Response } from "express";
+import { reserveItem, takeItem } from "../util/hardwareLibrary";
+import { ApiError } from "../util/errorHandling/apiError";
+import { HttpResponseCode } from "../util/errorHandling/httpResponseCode";
+/**
+ * A controller for handling hardware items
+ */
+export class HardwareController {
+
+  /**
+   * Reserves a item from the hardware library
+   */
+  public async reserve(req: Request, res: Response, next: Function): Promise<void> {
+    // Check the requested item in req.body.item can be reserved
+    // Using the hardware_item and reserved_hardware_item tables get the current reserved and taken
+    // if (stock - (reserved + taken) > 0)
+    // then the item can be reserved (reserve the item and return success (+ create qr))
+    // otherwise, return that the item can't be reserved
+    try {
+      const success: boolean = await reserveItem(req.user, req.body.item);
+      if (success) {
+        res.send({"message": "Item reserved!"});
+      } else {
+        return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Item cannot be reserved!"));
+      }
+    } catch (err) {
+      return next(new ApiError(HttpResponseCode.INTERNAL_ERROR, err.message));
+    }
+  }
+
+  /**
+   * Attempts to take the item from the hardware library
+   */
+  public async take(req: Request, res: Response, next: Function): Promise<void> {
+    try {
+      const success: boolean = await takeItem(req.body.token);
+      if (success) {
+        res.send({"message": "Item has been taken!"});
+      } else {
+        return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Item cannot be taken!"));
+      }
+    } catch (err) {
+      return next(new ApiError(HttpResponseCode.INTERNAL_ERROR, err.message));
+    }
+  }
+}

--- a/back-end/src/controllers/hardwareController.ts
+++ b/back-end/src/controllers/hardwareController.ts
@@ -17,9 +17,12 @@ export class HardwareController {
     // then the item can be reserved (reserve the item and return success (+ create qr))
     // otherwise, return that the item can't be reserved
     try {
-      const success: boolean = await reserveItem(req.user, req.body.item);
-      if (success) {
-        res.send({"message": "Item reserved!"});
+      const token: string = await reserveItem(req.user, req.body.item);
+      if (token) {
+        res.send({
+          "message": "Item reserved!",
+          "token": token
+        });
       } else {
         return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Item cannot be reserved!"));
       }

--- a/back-end/src/controllers/index.ts
+++ b/back-end/src/controllers/index.ts
@@ -1,1 +1,2 @@
 export * from "./userController";
+export * from "./hardwareController";

--- a/back-end/src/db/entity/hardwareItem.ts
+++ b/back-end/src/db/entity/hardwareItem.ts
@@ -1,0 +1,29 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from "typeorm";
+import { ReservedHardwareItem } from "./reservedHardwareItem";
+
+@Entity()
+export class HardwareItem {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column("varchar", { length: 255 })
+  name: string;
+
+  @Column("varchar", { length: 255 })
+  description: string;
+
+  @Column()
+  totalStock: number;
+
+  @Column()
+  reservedStock: number;
+
+  @Column()
+  takenStock: number;
+
+  @Column("varchar", { length: 1024 })
+  itemURL: string;
+
+  @OneToMany(() => ReservedHardwareItem, reservedHardwareItem => reservedHardwareItem.hardwareItem)
+  reservedHardwareItem: ReservedHardwareItem[];
+}

--- a/back-end/src/db/entity/hardwareItem.ts
+++ b/back-end/src/db/entity/hardwareItem.ts
@@ -6,7 +6,7 @@ export class HardwareItem {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column("varchar", { length: 255 })
+  @Column("varchar", { length: 255, nullable: false, unique: true })
   name: string;
 
   @Column("varchar", { length: 255 })

--- a/back-end/src/db/entity/index.ts
+++ b/back-end/src/db/entity/index.ts
@@ -1,2 +1,4 @@
 export * from "./user";
 export * from "./applicationUser";
+export * from "./hardwareItem";
+export * from "./reservedHardwareItem";

--- a/back-end/src/db/entity/reservedHardwareItem.ts
+++ b/back-end/src/db/entity/reservedHardwareItem.ts
@@ -1,0 +1,15 @@
+import { Entity, Column, ManyToOne } from "typeorm";
+import { HardwareItem } from "./hardwareItem";
+import { User } from "./user";
+
+@Entity()
+export class ReservedHardwareItem {
+  @ManyToOne(() => User, { primary: true })
+  user: User;
+
+  @ManyToOne(() => HardwareItem, { primary: true })
+  hardwareItem: HardwareItem;
+
+  @Column()
+  reservationStatus: boolean;
+}

--- a/back-end/src/db/entity/reservedHardwareItem.ts
+++ b/back-end/src/db/entity/reservedHardwareItem.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, ManyToOne } from "typeorm";
+import { Entity, Column, ManyToOne, JoinColumn } from "typeorm";
 import { HardwareItem } from "./hardwareItem";
 import { User } from "./user";
 
@@ -11,5 +11,11 @@ export class ReservedHardwareItem {
   hardwareItem: HardwareItem;
 
   @Column()
-  reservationStatus: boolean;
+  isReserved: boolean;
+
+  @Column("varchar")
+  reservationToken: string;
+
+  @Column("datetime")
+  reservationExpiry: Date;
 }

--- a/back-end/src/db/entity/user.ts
+++ b/back-end/src/db/entity/user.ts
@@ -1,4 +1,5 @@
-import { Entity, Column, PrimaryGeneratedColumn } from "typeorm";
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from "typeorm";
+import { ReservedHardwareItem } from "./reservedHardwareItem";
 
 @Entity()
 export class User {
@@ -22,4 +23,7 @@ export class User {
 
   @Column()
   repo: string;
+
+  @OneToMany(() => ReservedHardwareItem, reservedHardwareItem => reservedHardwareItem.user)
+  hardwareItems: ReservedHardwareItem[];
 }

--- a/back-end/src/routes/hardwareRouter.ts
+++ b/back-end/src/routes/hardwareRouter.ts
@@ -1,0 +1,21 @@
+import { Router } from "express";
+import { HardwareController } from "../controllers/hardwareController";
+import { checkIsLoggedIn, checkIsVolunteer } from "../util/user";
+
+export const hardwareRouter = (): Router => {
+  const router = Router();
+
+  const hardwareController = new HardwareController();
+
+  /**
+   * POST /hardware/reserve
+   */
+  router.post("/reserve", checkIsLoggedIn, hardwareController.reserve);
+
+  /**
+   * POST /hardware/take
+   */
+  router.post("/take", checkIsVolunteer, hardwareController.take);
+
+  return router;
+};

--- a/back-end/src/routes/hardwareRouter.ts
+++ b/back-end/src/routes/hardwareRouter.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { HardwareController } from "../controllers/hardwareController";
-import { checkIsLoggedIn, checkIsVolunteer } from "../util/user";
+import { checkIsLoggedIn, checkIsVolunteer, checkIsOrganizer } from "../util/user";
 
 export const hardwareRouter = (): Router => {
   const router = Router();
@@ -16,6 +16,16 @@ export const hardwareRouter = (): Router => {
    * POST /hardware/take
    */
   router.post("/take", checkIsVolunteer, hardwareController.take);
+
+  /**
+   * POST /hardware/addItems
+   */
+  router.post("/addItems", checkIsOrganizer, hardwareController.addAllItems);
+
+  /**
+   * GET /hardware/allItems
+   */
+  router.get("/allItems", hardwareController.getAllItems);
 
   return router;
 };

--- a/back-end/src/routes/index.ts
+++ b/back-end/src/routes/index.ts
@@ -1,3 +1,4 @@
 export * from "./userRouter";
 export * from "./mainRouter";
 export * from "./homeRouter";
+export * from "./hardwareRouter";

--- a/back-end/src/routes/mainRouter.ts
+++ b/back-end/src/routes/mainRouter.ts
@@ -1,11 +1,14 @@
 import { Router } from "express";
-import { userRouter, homeRouter } from "./";
+import { userRouter, homeRouter, hardwareRouter } from "./";
 
 /**
  * Top-level router for the app
  */
 export const mainRouter = (): Router => {
   const router = Router();
+
+  // Requests to /hardware/*
+  router.use("/hardware/", hardwareRouter());
 
   // Requests to /user/*
   router.use("/user/", userRouter());

--- a/back-end/src/util/hardwareLibrary/hardwareItemToken.ts
+++ b/back-end/src/util/hardwareLibrary/hardwareItemToken.ts
@@ -1,0 +1,32 @@
+import * as crypto from "crypto";
+import { ReservedHardwareItem } from "../../db/entity";
+import { getConnection } from "typeorm";
+
+/**
+ * Generates a random token for the hardware item reservation
+ */
+export const createToken = (): string => {
+  return crypto.randomBytes(16).toString("hex");
+};
+
+/**
+ * Gets the user and hardware item that the reservation token is linked to
+ * @param resToken Unique reservation token for the user reserved hardware item
+ */
+export const parseToken = async (resToken: string): Promise<ReservedHardwareItem> => {
+  let reservation: ReservedHardwareItem = undefined;
+  try {
+    reservation = await getConnection("hub")
+    .getRepository(ReservedHardwareItem)
+    .createQueryBuilder("reservation")
+    .innerJoin("reservation.user", "user")
+    .innerJoin("reservation.hardwareItem", "item")
+    .select(["user.id", "item.id", "reservation.isReserved", "reservation.reservationExpiry"])
+    .where("reservation.reservationToken = :token", { token: resToken })
+    .getOne();
+
+  } catch (err) {
+    throw new Error(`Lost connection to database (hub)! ${err}`);
+  }
+  return reservation;
+};

--- a/back-end/src/util/hardwareLibrary/hardwareItemValidation.ts
+++ b/back-end/src/util/hardwareLibrary/hardwareItemValidation.ts
@@ -67,8 +67,7 @@ export const reserveItemQuery = async (user: User, hardwareItem: HardwareItem): 
     newItemReservation.isReserved = true;
 
     // Sets the reservation expiry to be current time + 30 minutes
-    // newItemReservation.reservationExpiry = new Date(new Date().getTime() + (1000 * 60 * 30));
-    newItemReservation.reservationExpiry = new Date(new Date().getTime());
+    newItemReservation.reservationExpiry = new Date(new Date().getTime() + (1000 * 60 * 30));
 
     // Insert the reservation into the database
     await getConnection("hub")
@@ -117,6 +116,8 @@ export const isItemReservable = async (user: User, hardwareItem: HardwareItem): 
  */
 export const takeItem = async (token: string): Promise<boolean> => {
   const reservation: ReservedHardwareItem = await parseToken(token);
+  if (!reservation) return false;
+
   const userID: number = reservation.user.id,
     itemID: number = reservation.hardwareItem.id,
     isReserved: boolean = reservation.isReserved;

--- a/back-end/src/util/hardwareLibrary/hardwareItemValidation.ts
+++ b/back-end/src/util/hardwareLibrary/hardwareItemValidation.ts
@@ -7,12 +7,12 @@ import { getConnection } from "typeorm";
  * @param itemToReserve
  * @return A boolean indicating if the item was successfully reserved
  */
-export const reserveItem = async (user: User, itemToReserve: string): Promise<boolean> => {
+export const reserveItem = async (user: User, itemToReserve: string): Promise<string> => {
   const hardwareItem: HardwareItem = await getHardwareItemByName(itemToReserve);
   if (await isItemReservable(user, hardwareItem)) {
     return reserveItemQuery(user, hardwareItem);
   }
-  return false;
+  return undefined;
 };
 
 /**
@@ -57,7 +57,7 @@ export const getHardwareItemByID = async (hardwareItemID: number): Promise<Hardw
  * @param user
  * @param hardwareItem
  */
-export const reserveItemQuery = async (user: User, hardwareItem: HardwareItem): Promise<boolean> => {
+export const reserveItemQuery = async (user: User, hardwareItem: HardwareItem): Promise<string> => {
   try {
     // Create the new item reservation object
     const newItemReservation: ReservedHardwareItem = new ReservedHardwareItem();
@@ -82,7 +82,7 @@ export const reserveItemQuery = async (user: User, hardwareItem: HardwareItem): 
     .getRepository(HardwareItem)
     .increment({ id: hardwareItem.id }, "reservedStock", 1);
 
-    return true;
+    return newItemReservation.reservationToken;
   } catch (err) {
     throw new Error(`Lost connection to database (hub)! ${err}`);
   }

--- a/back-end/src/util/hardwareLibrary/hardwareItemValidation.ts
+++ b/back-end/src/util/hardwareLibrary/hardwareItemValidation.ts
@@ -1,0 +1,188 @@
+import { HardwareItem, User, ReservedHardwareItem } from "../../db/entity";
+import { createToken, parseToken } from "./hardwareItemToken";
+import { getConnection } from "typeorm";
+
+/**
+ * Finds the item by name and tries to reserve the item for the user
+ * @param itemToReserve
+ * @return A boolean indicating if the item was successfully reserved
+ */
+export const reserveItem = async (user: User, itemToReserve: string): Promise<boolean> => {
+  const hardwareItem: HardwareItem = await getHardwareItemByName(itemToReserve);
+  if (await isItemReservable(user, hardwareItem)) {
+    return reserveItemQuery(user, hardwareItem);
+  }
+  return false;
+};
+
+/**
+ * Gets the hardware item based on the item name
+ * @param itemToReserve the name of the item to reserve
+ */
+export const getHardwareItemByName = async (itemToReserve: string): Promise<HardwareItem> => {
+  try {
+    const item: HardwareItem = await getConnection("hub")
+      .getRepository(HardwareItem)
+      .createQueryBuilder("item")
+      .select([
+        "item.id",
+        "item.name",
+        "item.totalStock",
+        "item.reservedStock",
+        "item.takenStock"
+      ])
+      .where("item.name = :name", { name: itemToReserve })
+      .getOne();
+    return item ? item : undefined;
+  } catch (err) {
+    throw new Error(`Lost connection to database (hub)! ${err}`);
+  }
+};
+
+export const getHardwareItemByID = async (hardwareItemID: number): Promise<HardwareItem> => {
+  try {
+    const item: HardwareItem = await getConnection("hub")
+      .getRepository(HardwareItem)
+      .createQueryBuilder("item")
+      .where("item.id = :id", { id: hardwareItemID })
+      .getOne();
+    return item ? item : undefined;
+  } catch (err) {
+    throw new Error(`Lost connection to database (hub)! ${err}`);
+  }
+};
+
+/**
+ * Reserves the item, adding the reservation to the database
+ * @param user
+ * @param hardwareItem
+ */
+export const reserveItemQuery = async (user: User, hardwareItem: HardwareItem): Promise<boolean> => {
+  try {
+    // Create the new item reservation object
+    const newItemReservation: ReservedHardwareItem = new ReservedHardwareItem();
+    newItemReservation.user = user;
+    newItemReservation.hardwareItem = hardwareItem;
+    newItemReservation.reservationToken = createToken();
+    newItemReservation.isReserved = true;
+
+    // Sets the reservation expiry to be current time + 30 minutes
+    // newItemReservation.reservationExpiry = new Date(new Date().getTime() + (1000 * 60 * 30));
+    newItemReservation.reservationExpiry = new Date(new Date().getTime());
+
+    // Insert the reservation into the database
+    await getConnection("hub")
+    .createQueryBuilder()
+    .insert()
+    .into(ReservedHardwareItem)
+    .values(newItemReservation)
+    .execute();
+
+    // Increment the reservation count for the hardware item
+    await getConnection("hub")
+    .getRepository(HardwareItem)
+    .increment({ id: hardwareItem.id }, "reservedStock", 1);
+
+    return true;
+  } catch (err) {
+    throw new Error(`Lost connection to database (hub)! ${err}`);
+  }
+};
+
+/**
+ * Checks that the user is able to reserve the item
+ * @param user
+ * @param hardwareItem
+ */
+export const isItemReservable = async (user: User, hardwareItem: HardwareItem): Promise<boolean> => {
+  // Check the user has not reserved this item yet
+  const hasUserNotReserved: boolean = await getConnection("hub")
+  .getRepository(User)
+  .createQueryBuilder("user")
+  .select("user.id")
+  .innerJoinAndSelect("user.hardwareItems", "item")
+  .where("user.id = :id", { id: user.id })
+  .andWhere("item.hardwareItemId = :itemID", { itemID: hardwareItem.id })
+  .getCount() == 0;
+
+   // Check the requested item still has non reserved stock
+  const hasStock: boolean = hardwareItem.totalStock - (hardwareItem.reservedStock + hardwareItem.takenStock) > 0;
+
+  return hasStock && hasUserNotReserved;
+};
+
+/**
+ * We have one route for collecting a reservation and returning an item
+ * @param token
+ */
+export const takeItem = async (token: string): Promise<boolean> => {
+  const reservation: ReservedHardwareItem = await parseToken(token);
+  const userID: number = reservation.user.id,
+    itemID: number = reservation.hardwareItem.id,
+    isReserved: boolean = reservation.isReserved;
+
+  if (isReserved) {
+    // Checks that reservation is not expired
+    if (!isReservationValid(reservation.reservationExpiry)) return false;
+
+    await itemToBeTakenFromLibrary(userID, itemID);
+  } else {
+    await itemToBeReturnedToLibrary(itemID, token);
+  }
+
+  return true;
+};
+
+/**
+ * Helper function to check that the expiry time has not been reached
+ * @param expiryDate
+ */
+const isReservationValid = (expiryDate: Date): boolean => {
+  return Date.now() <= expiryDate.getTime();
+};
+
+export const itemToBeTakenFromLibrary = async (userID: number, hardwareItemID: number): Promise<void> => {
+    // The item is reserved and we mark the item as taken
+    try {
+      await getConnection("hub")
+      .createQueryBuilder()
+      .update(ReservedHardwareItem)
+      .set({isReserved: 0})
+      .where("userId = :uid", { uid: userID })
+      .andWhere("hardwareItemId = :hid", { hid: hardwareItemID })
+      .execute();
+
+      await getConnection("hub")
+      .createQueryBuilder()
+      .update(HardwareItem)
+      .set({
+        takenStock: () => "takenStock + 1",
+        reservedStock: () => "reservedStock - 1"
+       })
+      .where("id = :id", { id: hardwareItemID })
+      .execute();
+    } catch (err) {
+      throw new Error(`Lost connection to database (hub)! ${err}`);
+    }
+};
+
+export const itemToBeReturnedToLibrary = async (hardwareItemID: number, token: string): Promise<void> => {
+    // The item is being returned
+    try {
+      // Decrement the reservation count for the hardware item
+      await getConnection("hub")
+      .getRepository(HardwareItem)
+      .decrement({ id: hardwareItemID }, "takenStock", 1);
+
+      // Delete the user reservation from the database
+      await getConnection("hub")
+      .createQueryBuilder()
+      .delete()
+      .from(ReservedHardwareItem)
+      .where("reservationToken = :resToken", { resToken: token })
+      .execute();
+
+    } catch (err) {
+      throw new Error(`Lost connection to database (hub)! ${err}`);
+    }
+};

--- a/back-end/src/util/hardwareLibrary/hardwareItemValidation.ts
+++ b/back-end/src/util/hardwareLibrary/hardwareItemValidation.ts
@@ -116,7 +116,7 @@ export const isItemReservable = async (user: User, hardwareItem: HardwareItem): 
  */
 export const takeItem = async (token: string): Promise<boolean> => {
   const reservation: ReservedHardwareItem = await parseToken(token);
-  if (!reservation) return false;
+  if (!reservation) return undefined;
 
   const userID: number = reservation.user.id,
     itemID: number = reservation.hardwareItem.id,
@@ -124,14 +124,14 @@ export const takeItem = async (token: string): Promise<boolean> => {
 
   if (isReserved) {
     // Checks that reservation is not expired
-    if (!isReservationValid(reservation.reservationExpiry)) return false;
+    if (!isReservationValid(reservation.reservationExpiry)) return undefined;
 
     await itemToBeTakenFromLibrary(userID, itemID);
   } else {
     await itemToBeReturnedToLibrary(itemID, token);
   }
 
-  return true;
+  return isReserved;
 };
 
 /**

--- a/back-end/src/util/hardwareLibrary/index.ts
+++ b/back-end/src/util/hardwareLibrary/index.ts
@@ -1,0 +1,2 @@
+export * from "./hardwareItemValidation";
+export * from "./hardwareItemToken";

--- a/back-end/test/e2e/controllers/hardwareController.test.ts
+++ b/back-end/test/e2e/controllers/hardwareController.test.ts
@@ -1,0 +1,200 @@
+import { Express } from "express";
+import { buildApp } from "../../../src/app";
+import { User, HardwareItem, ReservedHardwareItem } from "../../../src/db/entity/";
+import { getConnection, ObjectLiteral } from "typeorm";
+import * as request from "supertest";
+import { HttpResponseCode } from "../../../src/util/errorHandling/httpResponseCode";
+import { exec } from "child_process";
+
+let bApp: Express;
+let sessionCookie: string;
+let userReservationToken: string;
+
+const testAttendeeUser: User = new User();
+testAttendeeUser.name = "Billy Tester II";
+testAttendeeUser.email = "billyII@testing.com";
+testAttendeeUser.password = "pbkdf2_sha256$30000$xmAiV8Wihzn5$BBVJrxmsVASkYuOI6XdIZoYLfy386hdMOF8S14WRTi8=";
+testAttendeeUser.authLevel = 0;
+testAttendeeUser.team = "TheTesters";
+testAttendeeUser.repo = "tests2.git";
+
+const piHardwareItem: HardwareItem = new HardwareItem();
+piHardwareItem.name = "Pi";
+piHardwareItem.description = "The Raspberry Pi is a series of small single-board computers developed in the United Kingdom.";
+piHardwareItem.totalStock = 4;
+piHardwareItem.reservedStock = 0;
+piHardwareItem.takenStock = 0;
+piHardwareItem.itemURL = "";
+
+const viveHardwareItem: HardwareItem = new HardwareItem();
+viveHardwareItem.name = "Vive";
+viveHardwareItem.description = "The HTC Vive is a virtual reality headset developed by HTC and Valve Corporation.";
+viveHardwareItem.totalStock = 2;
+viveHardwareItem.reservedStock = 0;
+viveHardwareItem.takenStock = 0;
+viveHardwareItem.itemURL = "";
+
+/**
+ * Preparing for the tests
+ */
+beforeAll((done: jest.DoneCallback): void => {
+  buildApp(async (builtApp: Express, err: Error): Promise<void> => {
+    if (err) {
+      console.error("Could not start server!");
+      done();
+    } else {
+      bApp = builtApp;
+      // Creating the test users
+      testAttendeeUser.id = (await getConnection("hub")
+        .createQueryBuilder()
+        .insert()
+        .into(User)
+        .values(testAttendeeUser)
+        .execute()).identifiers[0].id;
+
+      // Insert the hardware items into the database
+      piHardwareItem.id = (await getConnection("hub")
+        .createQueryBuilder()
+        .insert()
+        .into(HardwareItem)
+        .values(piHardwareItem)
+        .execute()).identifiers[0].id;
+
+      viveHardwareItem.id = (await getConnection("hub")
+        .createQueryBuilder()
+        .insert()
+        .into(HardwareItem)
+        .values(viveHardwareItem)
+        .execute()).identifiers[0].id;
+
+      // Login to the app as the attendee
+      const response = await request(bApp)
+        .post("/user/login")
+        .send({
+          email: testAttendeeUser.email,
+          password: "password123"
+        });
+
+      sessionCookie = response.header["set-cookie"].pop().split(";")[0];
+    }
+    done();
+  });
+});
+
+/**
+ * Testing hardware library requests
+ */
+describe("Hardware controller tests", (): void => {
+  /**
+   * Test that the take item route is protected
+   */
+  test("Should check that an attendee cannot access take route", async (): Promise<void> => {
+    const response = await request(bApp)
+      .post("/hardware/take")
+      .set("Cookie", sessionCookie)
+      .send({
+        token: "58zb1a546e4ad19b97bdcapc6ce",
+      });
+    expect(response.status).toBe(HttpResponseCode.FORBIDDEN);
+    expect(response.body.error).toBe("You do not have authorization to use this method");
+    expect(response.body.message).toBe("You are not logged in or you are not a volunteer!");
+  });
+
+  /**
+   * Test that an item is reserved when a user sends a request
+   */
+  test("Should check the specified item is reserved by the user", async (): Promise<void> => {
+    const response = await request(bApp)
+      .post("/hardware/reserve")
+      .set("Cookie", sessionCookie)
+      .send({
+        item: piHardwareItem.name,
+      });
+
+    expect(response.status).toBe(HttpResponseCode.OK);
+    expect(response.body.message).toBe("Item reserved!");
+    expect(response.body.token).not.toBeUndefined();
+    userReservationToken = response.body.token;
+  });
+
+  /**
+   * Test that once item is reserved, reservation is added to database
+   */
+  test("Should check that reservation is added to database", async (): Promise<void> => {
+    const reservation: ReservedHardwareItem = await getConnection("hub")
+      .getRepository(ReservedHardwareItem)
+      .createQueryBuilder("item")
+      .where("item.userId = :id", { id: testAttendeeUser.id })
+      .andWhere("item.hardwareItemId = :itemID", { itemID: piHardwareItem.id })
+      .getOne();
+    expect(reservation).not.toBeUndefined();
+    expect(reservation.isReserved).toBe(true);
+  });
+
+  /**
+   * Test that item can be taken and database is updated
+   */
+  test("Should check that item can be taken and database is updated", async (): Promise<void> => {
+    // Make it so the test user has access to take the items from the library for ease of use
+    await getConnection("hub")
+      .createQueryBuilder()
+      .update(User)
+      .set({ authLevel: 1 })
+      .where("id = :id", { id: testAttendeeUser.id })
+      .execute();
+
+    const response = await request(bApp)
+      .post("/hardware/take")
+      .set("Cookie", sessionCookie)
+      .send({
+        token: userReservationToken,
+    });
+    expect(response).not.toBeUndefined();
+    expect(response.body.message).toBe("Item has been taken from the library");
+  });
+
+  /**
+   * Test that item can be returned and database is updated
+   */
+  test("Should check that item can be returned and database is updated", async (): Promise<void> => {
+    const response = await request(bApp)
+      .post("/hardware/take")
+      .set("Cookie", sessionCookie)
+      .send({
+        token: userReservationToken,
+    });
+    expect(response).not.toBeUndefined();
+    expect(response.body.message).toBe("Item has been returned to the library");
+  });
+});
+
+/**
+ * Cleaning up after the tests
+ */
+afterAll(async (): Promise<void> => {
+  await getConnection("hub")
+    .createQueryBuilder()
+    .delete()
+    .from(ReservedHardwareItem)
+    .where("userId = :id1", { id1: testAttendeeUser.id })
+    .execute();
+
+  await getConnection("hub")
+    .createQueryBuilder()
+    .delete()
+    .from(User)
+    .where("id = :id1", { id1: testAttendeeUser.id })
+    .execute();
+
+  await getConnection("hub")
+    .createQueryBuilder()
+    .delete()
+    .from(HardwareItem)
+    .where("id = :id1", { id1: piHardwareItem.id })
+    .orWhere("id = :id2", { id2: viveHardwareItem.id })
+    .execute();
+
+  await getConnection("hub").close();
+  await getConnection("applications").close();
+});
+

--- a/back-end/test/unit/util/user/userValidation.test.ts
+++ b/back-end/test/unit/util/user/userValidation.test.ts
@@ -1,6 +1,6 @@
 import { buildApp } from "../../../../src/app";
 import { getConnection, createConnection } from "typeorm";
-import { User } from "../../../../src/db/entity";
+import { User, HardwareItem, ReservedHardwareItem } from "../../../../src/db/entity";
 import { Express } from "express";
 import { getUserByIDFromHub, getUserByEmailFromHub, validatePassword, validateUser } from "../../../../src/util/user/userValidation";
 
@@ -112,7 +112,9 @@ describe("User validation tests", (): void => {
       password: process.env.DB_PASSWORD,
       database: process.env.DB_DATABASE,
       entities: [
-        User
+        User,
+        HardwareItem,
+        ReservedHardwareItem
       ],
       synchronize: true,
       logging: false
@@ -125,7 +127,7 @@ describe("User validation tests", (): void => {
 /**
  * Cleaning up after the tests
  */
-afterAll(async (done: jest.DoneCallback): Promise<void> => {
+afterAll(async (): Promise<void> => {
   await getConnection("hub")
     .createQueryBuilder()
     .delete()
@@ -135,6 +137,4 @@ afterAll(async (done: jest.DoneCallback): Promise<void> => {
 
   await getConnection("applications").close();
   await getConnection("hub").close();
-
-  done();
 });


### PR DESCRIPTION
Pull request for #3 
Added functionality for the hardware library.
There are two new routes added:
- Reserving an item from the hardware library (accessible by all users)
- Taking and returning an item (accessible by volunteers or organizers)

Taking or returning an item is all done through the route `take`, we store the status of the reservation in the database.