### PR TITLE
Remove need to escape the item name, fix tests

### DIFF
--- a/src/public/js/hardware.js
+++ b/src/public/js/hardware.js
@@ -10,12 +10,12 @@ function closeQR() {
   $("#reservation-qr-token").html("");
 }
 
-function reserve(itemName) {
-  var quantity = $("#" + itemName.replace(/ /g, "-").replace(/-/g, "").replace(/./g, "").replace(/\/|(|)/g, "") + "-reservation-quantity").val();
+function reserve(itemID) {
+  var quantity = $("#" + itemID + "-reservation-quantity").val();
   $.post({
     url: "/hardware/reserve",
     data: {
-      item: itemName,
+      item: itemID,
       quantity: quantity
     },
     success: function(response) {

--- a/src/util/hardwareLibrary/hardwareItemValidation.ts
+++ b/src/util/hardwareLibrary/hardwareItemValidation.ts
@@ -12,35 +12,11 @@ import { HttpResponseCode } from "../errorHandling/httpResponseCode";
 export const reserveItem = async (user: User, itemToReserve: string, requestedQuantity?: number): Promise<string> => {
   if (!requestedQuantity) requestedQuantity = 1;
 
-  const hardwareItem: HardwareItem = await getHardwareItemByName(itemToReserve);
+  const hardwareItem: HardwareItem = await getHardwareItemByID(Number(itemToReserve));
   if (await isItemReservable(user, hardwareItem, requestedQuantity)) {
     return reserveItemQuery(user, hardwareItem, requestedQuantity);
   }
   return undefined;
-};
-
-/**
- * Gets the hardware item based on the item name
- * @param itemToReserve the name of the item to reserve
- */
-export const getHardwareItemByName = async (itemToReserve: string): Promise<HardwareItem> => {
-  try {
-    const item: HardwareItem = await getConnection("hub")
-      .getRepository(HardwareItem)
-      .createQueryBuilder("item")
-      .select([
-        "item.id",
-        "item.name",
-        "item.totalStock",
-        "item.reservedStock",
-        "item.takenStock"
-      ])
-      .where("item.name = :name", { name: itemToReserve })
-      .getOne();
-    return item ? item : undefined;
-  } catch (err) {
-    throw new Error(`Lost connection to database (hub)! ${err}`);
-  }
 };
 
 export const getHardwareItemByID = async (hardwareItemID: number): Promise<HardwareItem> => {
@@ -256,6 +232,7 @@ export const getAllHardwareItems = async (userId?: number): Promise<Object[]> =>
       reservationForItem = undefined;
     }
     formattedData.push({
+      "itemID": item.id,
       "itemName": item.name,
       "itemDescription": item.description,
       "itemURL": item.itemURL,

--- a/src/views/pages/hardware.ejs
+++ b/src/views/pages/hardware.ejs
@@ -63,10 +63,10 @@
                       <% } else { %>
                       <div>
                         <span><b>Quantity to take:</b></span>
-                        <input type="number" name="quantity" id="<%- item.itemName.replace(/ /g, '-').replace(/-/g, '').replace(/./g, '').replace(/\/|(|)/g, '') %>-reservation-quantity" class="number-input"
+                        <input type="number" name="quantity" id="<%- item.itemID %>-reservation-quantity" class="number-input"
                           placeholder="quantity" value="1">
                       </div>
-                      <button type="button" class="btn btn-success" data-dismiss="modal" onclick="reserve('<%- item.itemName %>')">TAKE</button>
+                      <button type="button" class="btn btn-success" data-dismiss="modal" onclick="reserve('<%- item.itemID %>')">TAKE</button>
                       <% } %>
                     </div>
                   </div>

--- a/test/e2e/controllers/hardwareController.test.ts
+++ b/test/e2e/controllers/hardwareController.test.ts
@@ -105,7 +105,7 @@ describe("Hardware controller tests", (): void => {
       .post("/hardware/reserve")
       .set("Cookie", sessionCookie)
       .send({
-        item: piHardwareItem.name,
+        item: piHardwareItem.id,
         quantity: 1
       });
 


### PR DESCRIPTION
For issue #60 

Since the fix for the item name problem in GUH, it worked by was hacky. I have replaced the item name with the item ID. We know it will be unique since it is assigned by the database.

Had to fix the tests as well, we should add more tests to the hardware library at some point.